### PR TITLE
Do not clear stack completely in try clauses

### DIFF
--- a/src/core/evalstack.cpp
+++ b/src/core/evalstack.cpp
@@ -24,8 +24,7 @@ std::optional<Value> EvaluationStack::popBack() {
 void EvaluationStack::pushBack(Value val) { stack.push_back(val); }
 
 void EvaluationStack::clear() {
-    stack.clear();
-    stack.shrink_to_fit();
+    stack.resize(barrier);
 }
 
 bool EvaluationStack::assertDepth(size_t count) const {


### PR DESCRIPTION
```clear``` call had a vulnerability, that allowed to clear the stack completely inside try clause. This behaviour is undesirable.