### PR TITLE
prelude: REPL in forthscript

### DIFF
--- a/include/prelude/repl.hpp
+++ b/include/prelude/repl.hpp
@@ -1,0 +1,3 @@
+#include <string>
+
+std::u32string getPreludeREPLSource();

--- a/src/io/prettyprint.cpp
+++ b/src/io/prettyprint.cpp
@@ -100,6 +100,7 @@ std::u32string prettyprint(Value val, Interpreter& interp) {
                     result.push_back(U' ');
                 }
             }
+            visited.erase(topTask.first.arr);
             continue;
         }
         Value& toPrint = topTask.first.arr->values[topTask.second];

--- a/src/io/termio.cpp
+++ b/src/io/termio.cpp
@@ -13,7 +13,9 @@ std::u32string toUTF32(const std::string &s);
 std::u32string readLine(const std::u32string &prompt,
                         [[maybe_unused]] bool disableAutocomplete) {
     std::string promptUtf8 = fromUTF32(prompt);
-    std::string result(linenoise(promptUtf8.c_str()));
+    char *raw = linenoise(promptUtf8.c_str());
+    std::string result(raw);
+    free(raw);
     linenoiseHistoryAdd(result.c_str());
     return toUTF32(result);
 }

--- a/src/prelude/repl.cpp
+++ b/src/prelude/repl.cpp
@@ -1,0 +1,8 @@
+#include <prelude/repl.hpp>
+
+std::u32string getPreludeREPLSource() {
+    return U"[get_stack_copy to_string \"\n# \" +] $_repl_prompt [True] "
+           U"[_repl_prompt! readln parse get_stack_size 1 - inline_try not "
+           U"[\"error: \" swap + \"Clearing stack...\" + writeln] if] "
+           U"inline_while";
+}

--- a/src/std/stack.cpp
+++ b/src/std/stack.cpp
@@ -46,7 +46,30 @@ ExecutionResult clearOp(Interpreter& interp) {
     return Success();
 }
 
+ExecutionResult getStackCopyOp(Interpreter& interp) {
+    const std::vector<Value>& stack = interp.evalStack.getStack();
+    Array* result = interp.heap.makeArrayObject(Value{}, stack.size());
+    for (size_t i = 0; i < stack.size(); ++i) {
+        result->values[i] = stack[i];
+    }
+    Value stackCopy;
+    stackCopy.type = ValueType::Array;
+    stackCopy.arr = result;
+    interp.evalStack.pushBack(stackCopy);
+    return Success();
+}
+
+ExecutionResult getStackSizeOp(Interpreter& interp) {
+    Value result;
+    result.type = ValueType::Numeric;
+    result.numericValue = interp.evalStack.getStackSize();
+    interp.evalStack.pushBack(result);
+    return Success();
+}
+
 void addStackManipNativeWords(Interpreter& interp) {
+    interp.defineNativeWord(U"get_stack_size", getStackSizeOp);
+    interp.defineNativeWord(U"get_stack_copy", getStackCopyOp);
     interp.defineNativeWord(U"drop", dropOp);
     interp.defineNativeWord(U"swap", swapOp);
     interp.defineNativeWord(U"over", overOp);


### PR DESCRIPTION
This PR replaces C++ REPL with one written in forthscript

* New inline versions of control flow statements that don't create a new scope were created (`inline_while`, `inline_if`, `inline_if_else`, `inline_try`, `inline_for`)
* Pretty printer can now handle nested arrays better
* `get_stack_copy` and `get_stack_size` native words were introduced. `get_stack_copy` copies stack to forthscript array and dumps it on the stack. `get_stack_size` pushes stack size on the stack (equivalent of `[get_stack_copy len]!`)
* REPL is now written in forthscript embedded in `prelude/repl.cpp` file.

Fixes #26